### PR TITLE
Fix JSON parsing in B2B agency agent

### DIFF
--- a/Agents/AI Service/agency.py
+++ b/Agents/AI Service/agency.py
@@ -171,10 +171,11 @@ class Agent:
         ).to_messages()
 
         try:
-            raw: str = await asyncio.wait_for(
-                asyncio.to_thread(lambda: self.llm.invoke(messages)),
+            message = await asyncio.wait_for(
+                asyncio.to_thread(self.llm.invoke, messages),
                 timeout,
             )
+            raw = getattr(message, "content", message)
             parsed = json.loads(raw)
             logger.info(f"{self.role} responded successfully")
             return parsed


### PR DESCRIPTION
## Summary
- decode Ollama responses by extracting the message content before loading JSON

## Testing
- `python3 -m py_compile Agents/AI\ Service/agency.py`
- `python3 -m py_compile Agents/Crawler/ai_lead_generation_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68471bf5e8508330a8cf4a22da791a84