### PR TITLE
Improve prompts and README for multi-agent app

### DIFF
--- a/Agents/AI Service/README.md
+++ b/Agents/AI Service/README.md
@@ -71,10 +71,16 @@ Before anything else, Please get your OpenAI API Key here: https://platform.open
     ```bash
     pip install -r requirements.txt
     ```
+3. **Start an Ollama server**:
+   ```bash
+   ollama serve
+   ```
+   The agents expect the server on http://localhost:11434. Set `OLLAMA_BASE_URL` to use a remote instance.
 
-3. **Run the Streamlit app**:
+
+4. **Run the Streamlit app**:
     ```bash
     streamlit run ai_services_agency/agency.py
     ```
 
-4. **Enter your OpenAI API Key** in the sidebar when prompted and start analyzing your startup idea!
+5. **Enter your OpenAI API Key** in the sidebar when prompted and start analyzing your startup idea!

--- a/Agents/AI Service/agency.py
+++ b/Agents/AI Service/agency.py
@@ -108,7 +108,7 @@ CEO Analysis:
 PM_PROMPT = ChatPromptTemplate.from_messages([
     SystemMessagePromptTemplate.from_template(
         '''
-You are the Product Manager. Craft a detailed three-phase roadmap using Markdown. Use H2 headers: '## MVP', '## Growth', and '## Scale'. Under each header, include bullet points for objectives and key deliverables.
+You are the Product Manager. Craft a **detailed** three-phase roadmap using Markdown. Use H2 headers: '## MVP', '## Growth', and '## Scale'. For each phase list **at least four** bullet points describing objectives and key deliverables so the downstream agents have plenty of context.
 '''    ),
     HumanMessagePromptTemplate.from_template(
         '''
@@ -143,7 +143,7 @@ Roadmap:
 MARKETING_PROMPT = ChatPromptTemplate.from_messages([
     SystemMessagePromptTemplate.from_template(
         '''
-You are the Marketing Manager. Using the product roadmap, craft a concise go-to-market plan. Include bullet points for target audience, primary channels, and messaging themes.
+You are the Marketing Manager. Using the product roadmap, produce a thorough go-to-market plan in JSON with keys 'audience', 'channels', and 'messaging'. Each key should map to an array of detailed bullet points.
 '''
     ),
     HumanMessagePromptTemplate.from_template(

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # LLMs and AI Agents In Progress
 Working on Creating a chatbot specifallay for a urdu poetry generation
+
+See `Agents/AI Service/README.md` for running the multi-agent demo. Make sure an Ollama server is running (``ollama serve``) before starting the agents.


### PR DESCRIPTION
## Summary
- clarify that an Ollama server is needed in the AI Service README
- update root README with a short note about running the Ollama backend
- tweak Product Manager and Marketing prompts for more detailed, structured answers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847e51ce9a083308388bd7d41482594