### PR TITLE
Switch Quora search to Google

### DIFF
--- a/Agents/Crawler/README.md
+++ b/Agents/Crawler/README.md
@@ -1,9 +1,9 @@
 ## 🎯 AI Lead Generation Agent
 
-This Streamlit application searches Quora with DuckDuckGo (filtered to the `quora.com` domain) and Reddit using the official API. It downloads each page with simple HTTP requests, extracts user interactions with a local Mistral model and saves the results to an Excel file.
+This Streamlit application searches Quora with Google (filtered to the `quora.com` domain) and Reddit using the official API. It downloads each page with simple HTTP requests, extracts user interactions with a local Mistral model and saves the results to an Excel file.
 
 ### Features
-- Searches Quora links via DuckDuckGo
+- Searches Quora links via Google
 - Queries Reddit posts through the Reddit API
 - Fetches pages directly via HTTP requests
 - Uses a local `mistral:7b-instruct` model for extraction

--- a/Agents/Crawler/ai_lead_generation_agent.py
+++ b/Agents/Crawler/ai_lead_generation_agent.py
@@ -1,5 +1,5 @@
 import streamlit as st
-from duckduckgo_search import DDGS
+from googlesearch import search
 from langchain_community.chat_models import ChatOllama
 from langchain.chains import LLMChain
 from langchain.prompts import ChatPromptTemplate
@@ -28,16 +28,13 @@ def init_reddit() -> praw.Reddit | None:
 reddit = init_reddit()
 
 
-def search_ddg_quora(company_description: str, num_links: int) -> List[str]:
-    """Return Quora URLs using DuckDuckGo."""
+def search_google_quora(company_description: str, num_links: int) -> List[str]:
+    """Return Quora URLs using Google search."""
     query = f"site:quora.com {company_description}"
-    with DDGS() as ddgs:
-        results = ddgs.text(query, region="wt-wt", safesearch="off", max_results=num_links * 2) or []
 
     urls: List[str] = []
-    for r in results:
-        url = r.get("href") or r.get("url")
-        if url and "quora.com" in url:
+    for url in search(query, num_results=num_links * 2, lang="en"):
+        if "quora.com" in url:
             urls.append(url)
         if len(urls) >= num_links:
             break
@@ -57,7 +54,7 @@ def search_reddit(company_description: str, limit: int) -> List[str]:
 
 
 def search_for_urls(company_description: str, num_links: int) -> List[str]:
-    quora_urls = search_ddg_quora(company_description, num_links // 2)
+    quora_urls = search_google_quora(company_description, num_links // 2)
     reddit_urls = search_reddit(company_description, num_links - len(quora_urls))
     combined = quora_urls + reddit_urls
     return combined[:num_links]

--- a/Agents/Crawler/requirements.txt
+++ b/Agents/Crawler/requirements.txt
@@ -1,5 +1,6 @@
 # Requires Reddit API credentials for praw
 duckduckgo_search
+googlesearch-python
 langchain_community
 pandas
 openpyxl


### PR DESCRIPTION
## Summary
- switch Quora search from DuckDuckGo to Google
- call the new search function in the crawler
- add `googlesearch-python` requirement
- note Google search usage in README

## Testing
- `python -m py_compile Agents/Crawler/ai_lead_generation_agent.py`
- `pip install googlesearch-python` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687526984fa88330aaa34c718e438351