### PR TITLE
Improve PDF formatting and agent prompts

### DIFF
--- a/Agents/AI Service/agency.py
+++ b/Agents/AI Service/agency.py
@@ -81,9 +81,14 @@ CEO_PROMPT = ChatPromptTemplate.from_messages([
     system_prompt(
         '''
 You are the Chief Strategy Officer. Review the provided project data and perform a Go/No-Go analysis.
-Summarize your decision, key risks, opportunities and recommendations using your own headings.
-Avoid strict JSON formatting and present the information in clear prose or bullet points.
-Keep the response under 200 words.
+Respond concisely in JSON using this format:
+{
+  "title": "<short title>",
+  "sections": [
+    {"heading": "<section heading>", "content": "<60 words max>"}
+  ]
+}
+Keep the entire response under 200 words.
 '''    ),
     human_prompt(
         '''
@@ -91,7 +96,7 @@ Project Data:
 ```json
 {project}
 ```
-Provide your analysis in free form using headings where appropriate.
+Return only the JSON described above.
 '''    ),
 ])
 
@@ -100,9 +105,8 @@ CTO_PROMPT = ChatPromptTemplate.from_messages([
     system_prompt(
         '''
 You are the CTO. Using the project data and the CEO's analysis, propose a system architecture and technology stack.
-Provide an overview, list the main components and outline a scalability strategy. You may include a title.
-Use headings and bullet points of your choosing and avoid strict JSON formatting.
-Keep the response under 200 words.
+Respond in the same JSON format as above with short sections describing the components and scalability plan.
+Limit each section to 60 words and keep the total under 200 words.
 '''    ),
     human_prompt(
         '''
@@ -114,6 +118,7 @@ CEO Analysis:
 ```json
 {CEO}
 ```
+Return only the JSON described above.
 '''
     ),
 ])
@@ -122,9 +127,9 @@ CEO Analysis:
 PM_PROMPT = ChatPromptTemplate.from_messages([
     system_prompt(
         '''
-You are the Product Manager. Create a three-phase roadmap. Name each phase meaningfully (e.g., "MVP", "Growth", "Scale") and list objectives and deliverables for each.
-Feel free to add a title and organise the roadmap using your own headings and bullet points instead of strict JSON.
-Keep the response under 200 words.
+You are the Product Manager. Create a three-phase roadmap. Name each phase meaningfully and list key objectives.
+Respond using the JSON format described above with one section per phase and an additional section for overall notes.
+Keep each section under 60 words and the full response under 200 words.
 '''    ),
     human_prompt(
         '''
@@ -136,6 +141,7 @@ CTO Specification:
 ```json
 {CTO}
 ```
+Return only the JSON described above.
 '''
     ),
 ])
@@ -145,9 +151,8 @@ DEV_PROMPT = ChatPromptTemplate.from_messages([
     system_prompt(
         '''
 You are the Lead Developer. For each roadmap phase describe the main tasks and outline a CI/CD pipeline.
-Use markdown headings for each phase and bullet points for tasks. Include a section titled "CI/CD Pipeline" with the tooling and overview.
-Avoid strict JSON formatting.
-Keep the response under 200 words.
+Reply in the same JSON format with one section per phase and a final section "CI/CD Pipeline".
+Limit section content to 60 words each and keep the total under 200 words.
 '''
     ),
     human_prompt(
@@ -156,6 +161,7 @@ Roadmap:
 ```markdown
 {PM}
 ```
+Return only the JSON described above.
 '''
     ),
 ])
@@ -164,9 +170,9 @@ Roadmap:
 MARKETING_PROMPT = ChatPromptTemplate.from_messages([
     system_prompt(
         '''
-You are the Marketing Manager. Based on the roadmap, craft a concise go-to-market plan. You may add a title.
-Describe the target audience, key channels and messaging themes using your own headings and bullet points instead of strict JSON.
-Keep the response under 200 words.
+You are the Marketing Manager. Based on the roadmap, craft a concise go-to-market plan.
+Return the plan in the same JSON format with short sections for audience, channels and messaging.
+Keep each section under 60 words and the total under 200 words.
 '''    ),
     human_prompt(
         '''
@@ -178,6 +184,7 @@ Roadmap:
 ```markdown
 {PM}
 ```
+Return only the JSON described above.
 '''
     ),
 ])
@@ -187,8 +194,8 @@ CLIENT_PROMPT = ChatPromptTemplate.from_messages([
     system_prompt(
         '''
 You are the Client Success Manager. Using the implementation details, outline the onboarding process, retention strategy and feedback loop.
-You may provide a title and organise the information in sections with bullet points. Avoid strict JSON formatting.
-Keep the response under 200 words.
+Respond using the same JSON format with concise sections for onboarding, retention and feedback.
+Keep the entire response under 200 words.
 '''    ),
     human_prompt(
         '''
@@ -196,6 +203,7 @@ Implementation Details:
 ```json
 {DEV}
 ```
+Return only the JSON described above.
 '''
     ),
 ])

--- a/Agents/AI Service/pdf_utils.py
+++ b/Agents/AI Service/pdf_utils.py
@@ -17,6 +17,7 @@ def init_styles():
             leading=32,
             alignment=1,
             spaceAfter=24,
+            fontName="Helvetica-Bold",
         )
     )
     styles.add(
@@ -39,6 +40,7 @@ def init_styles():
             textColor=colors.darkblue,
             spaceBefore=12,
             spaceAfter=8,
+            fontName="Helvetica-Bold",
         )
     )
     styles.add(
@@ -49,6 +51,7 @@ def init_styles():
             leading=18,
             spaceBefore=6,
             spaceAfter=4,
+            fontName="Helvetica-Bold",
         )
     )
     styles["Normal"].fontSize = 11
@@ -61,9 +64,15 @@ def to_flowables(data: Any, styles) -> List[Any]:
     """Convert nested data structures into ReportLab flowables."""
     flows: List[Any] = []
     if isinstance(data, dict):
-        for k, v in data.items():
-            flows.append(Paragraph(str(k).replace("_", " ").title(), styles["SubHeading"]))
-            flows.extend(to_flowables(v, styles))
+        if set(data.keys()) == {"heading", "content"}:
+            flows.append(Paragraph(str(data["heading"]), styles["SubHeading"]))
+            flows.extend(to_flowables(data["content"], styles))
+        else:
+            for k, v in data.items():
+                flows.append(
+                    Paragraph(str(k).replace("_", " ").title(), styles["SubHeading"])
+                )
+                flows.extend(to_flowables(v, styles))
     elif isinstance(data, list):
         if all(isinstance(i, (str, int, float)) for i in data):
             items = [Paragraph(str(i), styles["NormalLeft"]) for i in data]
@@ -83,6 +92,10 @@ def to_flowables(data: Any, styles) -> List[Any]:
     elif isinstance(data, (str, int, float)):
         flows.append(Paragraph(str(data), styles["NormalLeft"]))
     else:
-        flows.append(Preformatted(json.dumps(data, indent=2), styles["NormalLeft"]))
+        flows.append(
+            Preformatted(
+                json.dumps(data, indent=2), styles["NormalLeft"], maxLineLength=80
+            )
+        )
     return flows
 


### PR DESCRIPTION
## Summary
- emphasize bold fonts for sections in PDF output
- wrap long JSON blocks and detect custom heading structures
- update all agent prompts to return concise JSON

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687626bf390c83309d443dd97a551cd5